### PR TITLE
fix: error when retrieving checkpoints in NovitaClient.models()

### DIFF
--- a/src/novita_client/novita.py
+++ b/src/novita_client/novita.py
@@ -989,7 +989,7 @@ class NovitaClient:
         """
 
         if (self._model_list_cache is None or len(self._model_list_cache) == 0) or refresh:
-            res = self._get('/v2/models')
+            res = self._get('/v2/models', params={'type': 'checkpoint'})
 
             # TODO: fix this
             res_controlnet = self._get(


### PR DESCRIPTION
Hi, I just noticed that it is now necessary to specify the type of models when a call is made to `/v2/models`. Although this endpoint is deprecated, it is still very useful for people who have been using your API for several months :)

That's why I'm opening a PR with the fix (if it helps people who have been pulling their hair out because of the parsing error due to a bad API response)